### PR TITLE
Remove the assertion.

### DIFF
--- a/src/qt/qtwebkit/Source/WebCore/platform/KURL.cpp
+++ b/src/qt/qtwebkit/Source/WebCore/platform/KURL.cpp
@@ -331,7 +331,6 @@ void KURL::invalidate()
 KURL::KURL(ParsedURLStringTag, const String& url)
 {
     parse(url);
-    ASSERT(url == m_string);
 }
 
 KURL::KURL(const KURL& base, const String& relative)


### PR DESCRIPTION
Compiling with debugging enabled causes the asserts to execute. In this
case the assertion will fail if the input URL did not have a trailing
slash: https://bugs.webkit.org/show_bug.cgi?id=129606